### PR TITLE
extend soc_callback hook with extra info

### DIFF
--- a/doc/pyPlc.ini.template
+++ b/doc/pyPlc.ini.template
@@ -106,3 +106,5 @@ charge_parameter_backend = chademo
 # REST callback for SoC states. Comment out to disable. Do not leave a trailing slash
 soc_callback_enabled = False
 soc_callback_endpoint = http://1.1.1.1
+# Fallback value to use if the vehicle does not support the EVEnergyCapacity.Value
+soc_fallback_energy_capacity = 2700

--- a/evseNoGui.py
+++ b/evseNoGui.py
@@ -21,14 +21,38 @@ def cbShowStatus(s, selection=""):
 
 soc_callback_enabled = getConfigValueBool("soc_callback_enabled")
 soc_callback_url = getConfigValue("soc_callback_endpoint") if soc_callback_enabled else ""
+soc_fallback_energy_capacity = getConfigValue("soc_fallback_energy_capacity")
 
-def socStatusCallback(remaining_soc: int, full_soc: int = -1, bulk_soc: int = -1, origin: str = ""):
+def socStatusCallback(current_soc: int, full_soc: int = -1, energy_capacity: int = -1, energy_request: int = -1, evccid: str = "", origin: str = ""):
+    # Do some basic value checks and conversions
+    # Some cars do not support certain values and return 0, make sure we actually send -1
+
+    if (energy_capacity > 0):
+       # We need Wh, not something in between kWh and Wh
+       energy_capacity = energy_capacity * 10
+    else:
+       # Some cars do not supply energy capacity of their battery
+       # Support some kind of fallback value which would work for installations where typically one car charges
+       if (int(soc_fallback_energy_capacity) > 0):
+          energy_capacity = int(soc_fallback_energy_capacity) * 10
+       else:
+          energy_capacity = -1
+
+    if (energy_request > 0):
+       # We need Wh, not something in between kWh and Wh
+       energy_request = energy_request * 10
+    else:
+       energy_request = -1
+
     print(f"Received SoC status from {origin}.\n"
-          f"    Remaining {remaining_soc}% \n"
-          f"    Full at {full_soc}%\n"
-          f"    Bulk at {bulk_soc}%")
+          f"    Current SoC {current_soc}% \n"
+          f"    Full SoC {full_soc}%\n"
+          f"    Energy capacity {energy_capacity} Wh \n"
+          f"    Energy request {energy_request} Wh \n"
+          f"    EVCCID {evccid} \n")
+
     if soc_callback_enabled:
-        requests.post(f"{soc_callback_url}/modem?remaining_soc={remaining_soc}&full_soc={full_soc}&bulk_soc={bulk_soc}")
+        requests.post(f"{soc_callback_url}?current_soc={current_soc}&full_soc={full_soc}&energy_capacity={energy_capacity}&energy_request={energy_request}&evccid={evccid}")
 
 myMode = C_EVSE_MODE
 


### PR DESCRIPTION
This pull request aims to extend the soc_callback added by @ArendJanKramer. In a nutshell, it adds support for sending `EVEnergyCapacity`, `EVEnergyRequest`, and `EVCCID` values to the remote webhook.

I also added a fallback energy capacity configuration param to pyPLC.ini so you can also have the webhook contain an EnergyCapacity value even if the vehicle does not support this. That should provide the external EVSE controller with everything it needs to calculate the SoC.

I also renamed `remaining_soc` to `current_soc` and removed `bulk_soc`. If you like, I can refactor so we maintain backwards compatibility.

The changes in this pull request are tied to the pull request opened in https://github.com/serkri/SmartEVSE-3/pull/160.