### PR TITLE
Event-driven fsm_state publishes + PowerDelivery ChargeProgress signal

### DIFF
--- a/fsmEvse.py
+++ b/fsmEvse.py
@@ -10,7 +10,7 @@ from pyPlcInfoNumbers import *
 from helpers import prettyHexMessage, combineValueAndMultiplier
 from mytestsuite import *
 from random import random
-from configmodule import getConfigValueBool
+from configmodule import getConfigValue, getConfigValueBool
 from exiConnector import * # for EXI data handling/converting
 
 stateWaitForSupportedApplicationProtocolRequest = 0
@@ -213,6 +213,15 @@ class fsmEvse():
                 jsondict = json.loads(strConverterResult)
                 current_soc = int(jsondict.get("EVRESSSOC", -1))
                 self.publishSoCs(current_soc, origin="PowerDeliveryReq")
+                # DIN 70121: ReadyToChargeState 1=Start, 0=Stop. ISO 15118 uses
+                # the field "ChargeProgress" with Start/Stop/Renegotiate; fall
+                # back to that if present.
+                charge_progress = jsondict.get("ChargeProgress")
+                if charge_progress is None:
+                    ready = jsondict.get("ReadyToChargeState", "")
+                    charge_progress = "Start" if str(ready) == "1" else "Stop"
+                self.addToTrace("PowerDeliveryReq: ChargeProgress=%s" % charge_progress)
+                self.hardwareInterface.publishChargeProgress(charge_progress)
                 msg = addV2GTPHeader(exiEncode("E"+self.schemaSelection+"h")) # EDh for Encode, Din, PowerDeliveryResponse
                 if (testsuite_faultinjection_is_triggered(TC_EVSE_ResponseCode_Failed_for_PowerDeliveryRes)):
                     # send a PowerDeliveryResponse with Responsecode Failed
@@ -220,6 +229,17 @@ class fsmEvse():
                 self.addToTrace("responding " + prettyHexMessage(msg))
                 self.showDecodedTransmitMessage(msg)
                 self.publishStatus(INFONR_POWERDELIVERY, "PowerDelivery")
+                # On a Stop request, give the upstream orchestrator time to halt
+                # the power source before Tesla moves on to SessionStop and
+                # opens its contactor on a still-energised bus.
+                if charge_progress == "Stop":
+                    try:
+                        delay_s = float(getConfigValue("pre_powerdelivery_stop_delay_s"))
+                    except (ValueError, TypeError):
+                        delay_s = 1.0
+                    if delay_s > 0:
+                        self.addToTrace("delaying PowerDeliveryRes (Stop) by %.2fs" % delay_s)
+                        time.sleep(delay_s)
                 self.Tcp.transmit(msg)
                 self.enterState(stateWaitForFlexibleRequest) # todo: not clear, what is specified in DIN
             if (strConverterResult.find("ChargeParameterDiscoveryReq")>0):

--- a/hardwareInterface.py
+++ b/hardwareInterface.py
@@ -126,11 +126,17 @@ class hardwareInterface():
         self.callbackAddToTrace("[HARDWAREINTERFACE] " + s)
 
     def displayStateAndSoc(self, infonumber, state, soc):
-        if (getConfigValue("digital_output_device")=="mqtt") and (time() - self.lastStatePublish) >= 1:
+        # Always publish on state change; rate-limit only repeats. Otherwise
+        # fast transitions (WeldingDetection -> SessionStop -> Listening TCP)
+        # are swallowed by the 1 Hz throttle and downstream consumers miss them.
+        is_new_state = (state != self.lastPublishedState)
+        if (getConfigValue("digital_output_device")=="mqtt") and \
+           (is_new_state or (time() - self.lastStatePublish) >= 1):
             self.mqttclient.publish(getConfigValue("mqtt_topic") + "/fsm_state", state)
             if soc > 0:
                 self.mqttclient.publish(getConfigValue("mqtt_topic") + "/soc", str(soc))
             self.lastStatePublish = time()
+            self.lastPublishedState = state
         self.infonumber = infonumber
         if (soc>=0) and (soc<=100):
             self.soc_percent = soc
@@ -433,6 +439,7 @@ class hardwareInterface():
         self.rxbuffer = ""
 
         self.lastStatePublish = 0
+        self.lastPublishedState = None
         self.lastPowerReqPublish = 0
 
         self.findSerialPort()

--- a/hardwareInterface.py
+++ b/hardwareInterface.py
@@ -141,6 +141,12 @@ class hardwareInterface():
         if (soc>=0) and (soc<=100):
             self.soc_percent = soc
 
+    def publishChargeProgress(self, value):
+        # Publish Start/Stop/Renegotiate explicitly so external orchestrators
+        # can act on the EV's intent without inferring it from fsm_state.
+        if (getConfigValue("digital_output_device")=="mqtt"):
+            self.mqttclient.publish(getConfigValue("mqtt_topic") + "/charge_progress", value)
+
     def displayVehicleBatteryCapacity(self, batteryCapacity):
         self.addToTrace("displayVehicleBatteryCapacity " + str(batteryCapacity))
         if (getConfigValue("digital_output_device")=="mqtt"):


### PR DESCRIPTION
 Two related improvements to the MQTT interface

  ## 1. Publish fsm_state on every state change
  
  `displayStateAndSoc()` was rate-limiting all `fsm_state` MQTT publishes to
  1 Hz globally. CCS teardown transitions (`WeldingDetection` →
  `SessionStop` → `Listening TCP`) complete in ~300 ms, so consumers saw
  `CurrentDemand` → silence → `Listening TCP` and missed the intermediate
  states.
  
  Patch publishes immediately on every state CHANGE, keeps the 1 Hz cap
  only for repeats of the same state (the original intent: avoid flooding
  the broker with `CurrentDemand` pings during a long charge).

  ## 2. Surface PowerDelivery ChargeProgress + delay Stop response
  
  `PowerDeliveryReq` has two distinct meanings: Start vs Stop charging.
  The current `fsm_state="PowerDelivery"` doesn't disambiguate. Patch:

  1. Parses `ReadyToChargeState` (DIN 70121) or `ChargeProgress`
     (ISO 15118) from the decoded request.
  2. Publishes the resolved value (`Start` / `Stop` / `Renegotiate`)
     on `<mqtt_topic>/charge_progress`.
  3. On `Stop`, sleeps `pre_powerdelivery_stop_delay_s` seconds (default
     the new `fsm_state` and sending `PowerDeliveryRes` on TCP.
     
  The delay lets an external orchestrator halt its power supply.
  
  ## Tested on
  
  BeagleBone Black + FoccciCape with Tesla Model Y,
  MQTT mode. Repeated session stops both via Tesla button.
  
  ## Backwards compatibility
  
  - Existing consumers of `fsm_state` continue to work; they just see
    more transitions now (the missed intermediates).
  - New `charge_progress` topic is additive.
  - `pre_powerdelivery_stop_delay_s` defaults to 1.0 s; set to 0 to
    preserve the previous immediate-response behaviour.